### PR TITLE
just noticed a typo in docs

### DIFF
--- a/_posts/2012-06-17-documentation.md
+++ b/_posts/2012-06-17-documentation.md
@@ -191,7 +191,7 @@ As in Objective-C, you can express array and dictionary literals with square and
 <div class="highlight">
 <pre><span class="n">myarray</span> <span class="p">:=</span> <span class="p">[</span><span class="s">'a'</span><span class="p">,</span> <span class="s">'b'</span><span class="p">,</span> <span class="s">'c'</span><span class="p">]</span>
 
-<span class="n">mydict</span> <span class="p">:=</span> <span class="p">{</span> <span class="s">'a'</span> <span class="p">:</span> <span class="s">'A'</span><span class="p">,</span> <span class="s">'b'</span> <span class="p">:</span> <span class="s">'B'</span><span class="p">,</span> <span class="s">'c'</span><span class="p">,</span> <span class="s">'C'</span> <span class="p">}</span>
+<span class="n">mydict</span> <span class="p">:=</span> <span class="p">{</span> <span class="s">'a'</span> <span class="p">:</span> <span class="s">'A'</span><span class="p">,</span> <span class="s">'b'</span> <span class="p">:</span> <span class="s">'B'</span><span class="p">,</span> <span class="s">'c'</span><span class="p">:</span> <span class="s">'C'</span> <span class="p">}</span>
 </pre>
 </div>
 


### PR DESCRIPTION
the error is that in 
    mydict := { 'a' : 'A', 'b' : 'B', 'c', 'C' }
'C' doesn't have 'c' as a key
